### PR TITLE
fixed command for adding user to group

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ axpert-udev-setup
 Remeber to add user to dialout group if not already added to allow accessing serial port
 
 ```sh
-sudo useradd <current_user> dialout
+sudo usermod -aG dialout "$USER"
 ```
 
 ### CLI


### PR DESCRIPTION
useradd is not capable of adding an existing user to a group. 

Use usermod instead and get the username via $USER variable.